### PR TITLE
fix : y軸のラベルを消して、グラフ上部に単位(kcal or kg)を表示するように修正

### DIFF
--- a/src/screens/LogChart/LogChart.tsx
+++ b/src/screens/LogChart/LogChart.tsx
@@ -26,6 +26,7 @@ type ResultData = Record<
   {
     labels: string[];
     datasets: { data: Array<number> }[];
+    legend: string[];
   }
 >;
 
@@ -159,6 +160,7 @@ export const LogChart: React.FC<Navigation> = ({ navigation }) => {
             data: apiDataExercise.map((el) => el.value),
           },
         ],
+        legend: ['kcal'],
       },
       meal: {
         labels: dateMeal,
@@ -167,6 +169,7 @@ export const LogChart: React.FC<Navigation> = ({ navigation }) => {
             data: apiDataMeal.map((el) => el.value),
           },
         ],
+        legend: ['kcal'],
       },
       weight: {
         labels: dateWeight,
@@ -175,6 +178,7 @@ export const LogChart: React.FC<Navigation> = ({ navigation }) => {
             data: apiDataWeight.map((el) => el.value),
           },
         ],
+        legend: ['kg'],
       },
     });
     setIsLoading(false);
@@ -206,7 +210,6 @@ export const LogChart: React.FC<Navigation> = ({ navigation }) => {
                 data={resultData[selectedValue]}
                 width={Dimensions.get('window').width - 20} // from react-native
                 height={220}
-                yAxisSuffix={selectedValue === 'weight' ? 'kg' : 'kcal'}
                 yAxisInterval={1} // optional, defaults to 1
                 segments={5}
                 yLabelsOffset={selectedValue === 'weight' ? 10 : 7}


### PR DESCRIPTION
@anbyjap 
![スクリーンショット 2022-05-22 18 20 20](https://user-images.githubusercontent.com/101196108/169688512-951559ce-3c01-404c-9078-3170cc9da22c.png)
y軸ラベルの単位を消して、グラフの上部に単位を表示するように修正しました。
上記の写真はバックと繋がない状態で確認したものなので、つないだ状態でも正常に動くか確認してほしいです。